### PR TITLE
Refactor: Simplify favicon setting logic

### DIFF
--- a/src/UTILS/favicon.ts
+++ b/src/UTILS/favicon.ts
@@ -1,0 +1,14 @@
+export function setFavicon(url: string): void {
+  // Remove existing favicons
+  const existingFavicons = document.querySelectorAll('link[rel*="icon"]');
+  existingFavicons.forEach(favicon => favicon.remove());
+
+  const link = document.createElement('link');
+  link.rel = 'icon';
+  link.href = url;
+  // Modern browsers generally pick the best icon format,
+  // so explicitly setting type might not be necessary unless specific formats are used.
+  // link.type = 'image/png'; // Or 'image/x-icon' for .ico files
+
+  document.head.appendChild(link);
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 import "./UTILS/websocket-hook";
 
 import { background_song, kxs_logo, full_logo, background_image, survev_settings, kxs_settings } from "./UTILS/vars";
+import { setFavicon } from "./UTILS/favicon";
 import { intercept } from "./MECHANIC/intercept";
 
 import KxsClient from "./KxsClient";
@@ -34,37 +35,10 @@ if (window.location.href === "https://kxs.rip/") {
 	const backgroundElement = document.getElementById("background");
 	if (backgroundElement) backgroundElement.style.backgroundImage = `url("${background_image}")`;
 
-	const existingFavicons = document.querySelectorAll('link[rel*="icon"]');
-	existingFavicons.forEach(favicon => favicon.remove());
-
-	const isChrome = /Chrome/.test(navigator.userAgent) && !/Edge/.test(navigator.userAgent);
-	const isFirefox = /Firefox/.test(navigator.userAgent);
-
-	const favicon = document.createElement('link');
-
-	if (isFirefox) {
-		favicon.rel = 'icon';
-		favicon.type = 'image/png';
-		favicon.href = kxs_logo;
-	} else if (isChrome) {
-		favicon.rel = 'shortcut icon';
-		favicon.href = kxs_logo;
-
-		const link = document.createElement('link');
-		link.rel = 'icon';
-		link.href = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+P+/HgAFdwI2QJIiywAAAABJRU5ErkJggg==';
-		document.head.appendChild(link);
-		setTimeout(() => {
-			link.href = kxs_logo;
-		}, 50);
-	} else {
-		favicon.rel = 'icon';
-		favicon.href = kxs_logo;
-	}
+	setFavicon(kxs_logo);
 
 	const kxsClient = new KxsClient();
 
-	document.head.appendChild(favicon);
 	document.title = "KxsClient";
 
 	const uiStatsLogo = document.querySelector('#ui-stats-logo') as HTMLElement | null;


### PR DESCRIPTION
I encapsulated favicon setting logic into a new `setFavicon` function in `src/UTILS/favicon.ts`. Then, I updated `src/index.ts` to use this new function.

This change simplifies the favicon handling in the main entry point and makes the logic more reusable and maintainable. I also removed browser-specific hacks in favor of a more standard approach.